### PR TITLE
Make the character-limited textarea more intuitive

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,7 +159,8 @@
         <div class="row-fluid">
           <div class="span6 offset3">
             <div class="form-group">
-              <textarea id="countTextarea" placeholder="Start typing.." rows="4"></textarea>
+              <textarea id="countTextarea" placeholder="Start typing.." rows="4" maxlength="100"></textarea>
+              <p class="pull-right" style="color: rgb(248, 248, 248); margin-right: -20px;"><span id="characterCounter"></span> characters remaining</p>
             </div>
           </div>
         </div>

--- a/js/demo.js
+++ b/js/demo.js
@@ -137,13 +137,18 @@ document.getElementById("saveButton").onclick = function() {
 }
 
 var textareaCount = document.getElementById("countTextarea");
-textareaCount.onkeyup = function() {
-  //console.log(this.value.length);
-  var prgjs = progressJs("#countTextarea").setOptions({ theme: 'blackRadiusInputs' }).start();
+var characterCounter = document.getElementById("characterCounter");
 
-  if (this.value.length <= 100) {
-    prgjs.set(this.value.length);
-  } else {
-    this.value = this.value.substring(0 ,100);
-  }
-};
+function countCharacters() {
+  var prgjs = progressJs("#countTextarea").setOptions({ theme: 'blackRadiusInputs' }).start();
+  
+  var length = textareaCount.value.length;
+  var maxLength = textareaCount.getAttribute("maxlength");
+  var progress = length / maxLength * 100;
+  
+  prgjs.set(progress);
+  characterCounter.textContent = maxLength - length;
+}
+
+textareaCount.onkeypress = textareaCount.onkeyup = countCharacters;
+countCharacters();


### PR DESCRIPTION
This solves the problem raised in issue #5. Namely, it:
- Prevents input from exceeding the textarea limit when holding down a key
- Prevents pasting text that would exceed the textarea limit
- Updates the progress bar even when holding down a key

The solution is cross-browser, though very old browsers might not work with it.
This should also fix issue #1.

Review welcome.
