### PR TITLE
Remove moot `version` property from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "Progress.js",
-  "version": "0.1.0",
   "description": "Themeable HTML5 progress bar library",
   "keywords": ["progress", "progressbar", "loading"],
   "homepage": "http://usablica.github.io/progress.js/",


### PR DESCRIPTION
Per bower/bower.json-spec@a325da3

Also their maintainer says they probably won't ever use it: http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property
